### PR TITLE
Cover Flow: Build a custom version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2616,11 +2616,6 @@
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
     },
-    "bowser": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/bowser/-/bowser-1.9.4.tgz",
-      "integrity": "sha512-9IdMmj2KjigRq6oWhmwv1W36pDuA4STQZ8q6YO9um+x07xgYNCD3Oou+WP/3L1HNz7iqythGet3/p4wvc8AAwQ=="
-    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -4121,15 +4116,6 @@
         }
       }
     },
-    "css-in-js-utils": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/css-in-js-utils/-/css-in-js-utils-2.0.1.tgz",
-      "integrity": "sha512-PJF0SpJT+WdbVVt0AOYp9C8GnuruRlL/UFW7932nLWmFLQTaWEzTBQEx7/hn4BuV+WON75iAViSUJLiU3PKbpA==",
-      "requires": {
-        "hyphenate-style-name": "^1.0.2",
-        "isobject": "^3.0.1"
-      }
-    },
     "css-loader": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-1.0.0.tgz",
@@ -5490,11 +5476,6 @@
           }
         }
       }
-    },
-    "exenv": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/exenv/-/exenv-1.2.2.tgz",
-      "integrity": "sha1-KueOhdmJQVhnCwPUe+wfA72Ru50="
     },
     "exit": {
       "version": "0.1.2",
@@ -7922,11 +7903,6 @@
       "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
       "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM="
     },
-    "hyphenate-style-name": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.3.tgz",
-      "integrity": "sha512-EcuixamT82oplpoJ2XU4pDtKGWQ7b00CD9f1ug9IaQ3p1bkHMiKCZ9ut9QDI6qsa6cpUuB+A/I+zLtdNK4n2DQ=="
-    },
     "iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -8053,15 +8029,6 @@
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
       "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
-    },
-    "inline-style-prefixer": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/inline-style-prefixer/-/inline-style-prefixer-4.0.2.tgz",
-      "integrity": "sha512-N8nVhwfYga9MiV9jWlwfdj1UDIaZlBFu4cJSJkIr7tZX7sHpHhGR5su1qdpW+7KPL8ISTvCIkcaFi/JdBknvPg==",
-      "requires": {
-        "bowser": "^1.7.3",
-        "css-in-js-utils": "^2.0.0"
-      }
     },
     "inquirer": {
       "version": "6.2.2",
@@ -13067,16 +13034,6 @@
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.1.1.tgz",
       "integrity": "sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA=="
     },
-    "radium": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/radium/-/radium-0.25.1.tgz",
-      "integrity": "sha512-OA6DXjMQ5jlCc0zV8HCaQfDjHPdbhAoGUkVQDFaXZR/KKczLKrrkO+lq0fZM1S3uGi2q1ac3UFXhkW4Qp57NIw==",
-      "requires": {
-        "exenv": "^1.2.1",
-        "inline-style-prefixer": "^4.0.0",
-        "prop-types": "^15.5.8"
-      }
-    },
     "raf": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
@@ -13178,14 +13135,6 @@
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.4.tgz",
           "integrity": "sha512-05qQ5hXShcqGkPZpXEFLIpxayZscVD2kuMBZewxiIPPEagukO4mqgPA9CWhUvFBJfy3ODdK2p9xyHh7FTU9/7A=="
         }
-      }
-    },
-    "react-coverflow": {
-      "version": "0.2.19",
-      "resolved": "https://registry.npmjs.org/react-coverflow/-/react-coverflow-0.2.19.tgz",
-      "integrity": "sha512-g+ojjyNc7c4vNj2JGf1iZ4mJD+yOH8iBPEdxt3o7pMkEVS1hQBlV8kRRqcfLhqj8CUJkt1ZRF2UW05jTgBwGCQ==",
-      "requires": {
-        "radium": "^0.25.1"
       }
     },
     "react-deep-force-update": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "dependencies": {
     "feather-icons": "^4.17.0",
     "react": "^16.7.0",
-    "react-coverflow": "^0.2.19",
     "react-dom": "^16.7.0",
     "react-lazy-load": "^3.0.13",
     "react-redux": "^6.0.0",

--- a/src/js/api/reducer.js
+++ b/src/js/api/reducer.js
@@ -18,11 +18,11 @@ const apiReducer = (state = initialState, action) => {
          return {
             ...state,
             artistData: {
-               ...state.data.artistData,
+               ...state.artistData,
                [action.name]: action.albums,
             },
             albumData: {
-               ...state.data.albumData,
+               ...state.albumData,
                ...action.albumData,
             },
          };
@@ -30,7 +30,7 @@ const apiReducer = (state = initialState, action) => {
          return {
             ...state,
             albumData: {
-               ...state.data.albumData,
+               ...state.albumData,
                ...action.albumData,
             },
             albums: action.albums,
@@ -39,7 +39,7 @@ const apiReducer = (state = initialState, action) => {
          return {
             ...state,
             albumData: {
-               ...state.data.albumData,
+               ...state.albumData,
                [action.album]: action.tracks,
             },
          };

--- a/src/js/toolbox/components/cover_flow/cover.js
+++ b/src/js/toolbox/components/cover_flow/cover.js
@@ -1,0 +1,83 @@
+import React, { Component } from 'react';
+import styled, { css } from 'styled-components';
+
+const Container = styled.div`
+   flex: 0 0 auto;
+   height: 6em;
+   width: 6em;
+   box-sizing: border-box;
+   transition: all 0.3s;
+   border: 1px solid #f1f1f1;
+   background: url("http://tannerv.ddns.net:12345/SpotiFree/${props =>
+      props.img}");
+   background-size: contain;
+   -webkit-box-reflect: below 0px -webkit-gradient(linear, left top, left bottom, from(transparent), color-stop(70%, transparent) , to(rgba(250, 250, 250, 0.1)));
+
+   ${props =>
+      props.displayStyle === 'center' &&
+      css`
+         transform: scale(1.5);
+         z-index: 2;
+      `};
+
+   ${props =>
+      props.displayStyle === 'left-left-of-center' &&
+      css`
+         margin-right: -80px;
+         transform: rotateY(80deg) scale(1.3);
+         z-index: 0;
+      `};
+
+   ${props =>
+      props.displayStyle === 'left-of-center' &&
+      css`
+         transform: translateX(20px) rotateY(80deg) scale(1.3);
+         z-index: 1;
+      `};
+
+   ${props =>
+      props.displayStyle === 'right-of-center' &&
+      css`
+         transform: translateX(-20px) rotateY(-80deg) scale(1.3);
+         z-index: 1;
+      `};
+
+   ${props =>
+      props.displayStyle === 'right-right-of-center' &&
+      css`
+         margin-left: -80px;
+         transform: rotateY(-80deg) scale(1.3);
+         z-index: 0;
+      `};
+`;
+
+class Cover extends Component {
+   get displayStyle() {
+      const { index, activeIndex } = this.props;
+      if (index < activeIndex) {
+         return index < activeIndex - 1
+            ? 'left-left-of-center'
+            : 'left-of-center';
+      } else if (index > activeIndex) {
+         return index > activeIndex + 1
+            ? 'right-right-of-center'
+            : 'right-of-center';
+      }
+      return 'center';
+   }
+
+   render() {
+      const { data, index } = this.props;
+      const displayStyle = this.displayStyle;
+
+      return (
+         <Container
+            img={data.artwork}
+            index={index}
+            displayStyle={displayStyle}
+         />
+      );
+   }
+}
+
+export default Cover;

--- a/src/js/toolbox/components/cover_flow/index.js
+++ b/src/js/toolbox/components/cover_flow/index.js
@@ -1,0 +1,86 @@
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import styled from 'styled-components';
+import Cover from './cover';
+import * as ApiActions from '../../../api/actions';
+
+const Container = styled.div`
+   display: flex;
+   flex-direction: column;
+   height: 92%;
+   width: 100%;
+`;
+
+const AlbumContainer = styled.div`
+   position: relative;
+   display: flex;
+   align-items: center;
+   height: 11em;
+   transform-style: preserve-3d;
+   perspective: 500px;
+   transform: translateX(${props => 112 - props.activeIndex * 32}px);
+   transition: all 0.3s;
+   opacity: ${props => props.isHidden && 0};
+`;
+
+const Text = styled.h3`
+   text-align: center;
+   margin: 0;
+   font-size: 15px;
+`;
+
+const mapStateToProps = state => ({
+   apiState: state.apiState,
+});
+
+const mapDispatchToProps = dispatch => ({
+   fetchAlbums: () => dispatch(ApiActions.fetchAlbums()),
+});
+
+class CoverFlow extends Component {
+   state = {
+      hidden: true,
+   };
+
+   componentDidMount() {
+      const { albums } = this.props.apiState;
+      console.log(albums);
+
+      if (!albums.length) {
+         this.props.fetchAlbums();
+      }
+
+      setTimeout(() => {
+         this.setState({ hidden: false });
+      }, 300);
+   }
+
+   render() {
+      const { apiState, activeIndex } = this.props;
+      const { albums } = apiState;
+      const { hidden } = this.state;
+
+      return (
+         <Container>
+            <AlbumContainer activeIndex={activeIndex} isHidden={hidden}>
+               {albums.map((album, index) => (
+                  <Cover
+                     key={`album-${album.album}`}
+                     data={album}
+                     index={index}
+                     activeIndex={activeIndex}
+                  />
+               ))}
+            </AlbumContainer>
+            {albums.length && (
+               <React.Fragment>
+                  <Text>{albums[activeIndex].album}</Text>
+                  <Text>{albums[activeIndex].artist}</Text>
+               </React.Fragment>
+            )}
+         </Container>
+      );
+   }
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(CoverFlow);

--- a/src/js/toolbox/index.js
+++ b/src/js/toolbox/index.js
@@ -2,5 +2,6 @@ export { default as Button } from './components/button';
 export { default as Api } from './components/api';
 export { default as Icon } from './components/icon';
 export { default as Knob } from './components/knob';
+export { default as CoverFlow } from './components/cover_flow';
 
 export { default as constants } from './constants';

--- a/src/js/views/cover_flow/container.js
+++ b/src/js/views/cover_flow/container.js
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 import styled from 'styled-components';
 import * as ApiActions from '../../api/actions';
 import Header from '../header';
-import Coverflow from 'react-coverflow';
+import { CoverFlow } from '../../toolbox';
 
 const Container = styled.div`
    position: absolute;
@@ -29,7 +29,7 @@ const mapDispatchToProps = dispatch => ({
 
 let artistList = [];
 
-class CoverFlow extends Component {
+class CoverFlowContainer extends Component {
    static getDerivedStateFromProps(nextProps, prevState) {
       const { apiState, viewState, index } = nextProps;
       const { scrollOffset } = prevState;
@@ -46,7 +46,7 @@ class CoverFlow extends Component {
                ? scrollOffset - 1
                : scrollIndex > scrollOffset + 9
                   ? scrollOffset + 1
-               : scrollOffset,
+                  : scrollOffset,
       };
    }
 
@@ -78,25 +78,47 @@ class CoverFlow extends Component {
    }
 
    render() {
-      return this.props.isActive && (
-         <Container className="cover-flow">
-            <Header />
-            <Coverflow
-               displayQuantityOfSide={1}
-               navigation={false}
-               clickable={false}
-               active={this.scrollIndex}
-            >
-               <img alt="album" src="https://www.w3schools.com/html/pic_trulli.jpg" />
-               <img alt="album2" src="https://www.w3schools.com/html/pic_trulli.jpg" />
-               <img alt="album3" src="https://www.w3schools.com/html/pic_trulli.jpg" />
-            </Coverflow>
-         </Container>
+      return (
+         this.props.isActive && (
+            <Container className="cover-flow">
+               <Header />
+               <CoverFlow
+                  data={[
+                     {
+                        name: 'Coldplay',
+                        src: 'https://www.w3schools.com/html/pic_trulli.jpg',
+                     },
+                     {
+                        name: 'Coldplay',
+                        src: 'https://www.w3schools.com/html/pic_trulli.jpg',
+                     },
+                     {
+                        name: 'Coldplay',
+                        src: 'https://www.w3schools.com/html/pic_trulli.jpg',
+                     },
+                     {
+                        name: 'Coldplay',
+                        src: 'https://www.w3schools.com/html/pic_trulli.jpg',
+                     },
+                     {
+                        name: 'Coldplay',
+                        src: 'https://www.w3schools.com/html/pic_trulli.jpg',
+                     },
+                     {
+                        name: 'Coldplay',
+                        src: 'https://www.w3schools.com/html/pic_trulli.jpg',
+                     },
+                     {
+                        name: 'Coldplay',
+                        src: 'https://www.w3schools.com/html/pic_trulli.jpg',
+                     },
+                  ]}
+                  activeIndex={this.scrollIndex}
+               />
+            </Container>
+         )
       );
    }
 }
 
-export default connect(
-   mapStateToProps,
-   mapDispatchToProps,
-)(CoverFlow);
+export default connect(mapStateToProps, mapDispatchToProps)(CoverFlowContainer);

--- a/src/js/views/cover_flow/index.js
+++ b/src/js/views/cover_flow/index.js
@@ -19,7 +19,7 @@ const mapDispatchToProps = dispatch => ({
 
 let artistList = [];
 
-class CoverFlowView extends Component {
+class CoverFlowContainer extends Component {
    static get metadata() {
       return {
          name: 'Cover Flow',
@@ -82,4 +82,4 @@ class CoverFlowView extends Component {
 export default connect(
    mapStateToProps,
    mapDispatchToProps,
-)(CoverFlowView);
+)(CoverFlowContainer);

--- a/src/js/views/view_container.js
+++ b/src/js/views/view_container.js
@@ -3,7 +3,7 @@ import styled, { css } from 'styled-components';
 import { connect } from 'react-redux';
 import Header from './header';
 import DefaultPreview from './default_preview';
-import CoverFlow from './cover_flow/cover_flow';
+import CoverFlowContainer from './cover_flow/container';
 
 const Container = styled.div`
    position: relative;
@@ -180,7 +180,7 @@ class ViewContainer extends Component {
       }
       return (
          <Container>
-            <CoverFlow isActive={inCoverFlow} />
+            <CoverFlowContainer isActive={inCoverFlow} />
             <MenuStack isHidden={inCoverFlow} className="menu-stack">
                <Header className="header" />
                <ViewStackContainer>


### PR DESCRIPTION
Who needs external npm packages? I was about to use `react-coverflow` as a baseline, but first off it was a ridiculously large package and didn't even look that good. It also used a bunch of dependencies that we could do without.

So I built it myself! It's not perfect yet (my math is slightly off),
but it looks pretty dang close to the iPod cover flow.